### PR TITLE
Hive Error Handlers

### DIFF
--- a/lib/steem/base_error.rb
+++ b/lib/steem/base_error.rb
@@ -74,6 +74,22 @@ module Steem
         raise Steem::ArgumentError, "#{context}: #{error.message}", build_backtrace(error)
       end
       
+      if error.message.include? 'Invalid parameters'
+        raise Steem::ArgumentError, "#{context}: #{error.message}", build_backtrace(error)
+      end
+      
+      if error.message.include? 'invalid account (not specified) (hivemind-alpha)'
+        raise Steem::HivemindArgumentError, "#{context}: #{error.message}", build_backtrace(error)
+      end
+      
+      if error.message.include? 'invalid account name type (hivemind-alpha)'
+        raise Steem::HivemindArgumentError, "#{context}: #{error.message}", build_backtrace(error)
+      end
+      
+      if error.message.include? 'tag must be a string (hivemind-alpha)'
+        raise Steem::HivemindArgumentError, "#{context}: #{error.message}", build_backtrace(error)
+      end
+      
       if error.message.include? 'blk->transactions.size() > itr->trx_in_block'
         raise Steem::VirtualOperationsNotAllowedError, "#{context}: #{error.message}", build_backtrace(error)
       end
@@ -189,6 +205,7 @@ module Steem
   class TheftError < ArgumentError; end
   class NonZeroRequiredError < ArgumentError; end
   class UnexpectedAssetError < ArgumentError; end
+  class HivemindArgumentError < ArgumentError; end
   class TransactionExpiredError < BaseError; end
   class DuplicateTransactionError < TransactionExpiredError; end
   class NonCanonicalSignatureError < TransactionExpiredError; end

--- a/lib/steem/rpc/base_client.rb
+++ b/lib/steem/rpc/base_client.rb
@@ -164,9 +164,9 @@ module Steem
       
       # @private
       def raise_error_response(rpc_method_name, rpc_args, response)
-        raise UnknownError, "#{rpc_method_name}: #{response}" if response.error.nil?
-        
-        error = response.error
+        if (error = response.error || response.result.error).nil?
+          raise UnknownError, "#{rpc_method_name}: #{response}"
+        end
         
         if error.message == 'Invalid Request'
           raise Steem::ArgumentError, "Unexpected arguments: #{rpc_args.inspect}.  Expected: #{rpc_method_name} (#{args_keys_to_s(rpc_method_name)})"

--- a/lib/steem/rpc/http_client.rb
+++ b/lib/steem/rpc/http_client.rb
@@ -109,8 +109,14 @@ module Steem
             end
             
             [response].flatten.each_with_index do |r, i|
-              if defined?(r.error) && !!r.error
-                if !!r.error.message
+              error = if defined?(r.error) && !!r.error
+                r.error
+              elsif defined?(r.result.error) && !!r.result.error
+                r.result.error
+              end
+              
+              if !!error
+                if !!error.message
                   begin
                     rpc_method_name = "#{api_name}.#{api_method}"
                     rpc_args = [request_object].flatten[i]
@@ -119,7 +125,7 @@ module Steem
                     throw retry_timeout(:tota_cera_pila, e)
                   end
                 else
-                  raise Steem::ArgumentError, r.error.inspect
+                  raise Steem::ArgumentError, error.inspect
                 end
               end
             end

--- a/test/steem/api_test.rb
+++ b/test/steem/api_test.rb
@@ -2,19 +2,19 @@ require 'test_helper'
 
 module Steem
   class ApiTest < Steem::Test
-    METHOD_NAMES_1_ARG = %i(get_account_votes get_block get_block_header
-      get_blog_authors get_comment_discussions_by_payout
-      get_conversion_requests get_discussions_by_active
-      get_discussions_by_blog get_discussions_by_cashout
-      get_discussions_by_children get_discussions_by_comments
+    METHOD_NAMES_1_ARG = %i(get_block get_block_header
+      get_comment_discussions_by_payout
+      get_conversion_requests
+      get_discussions_by_blog
+      get_discussions_by_comments
       get_discussions_by_created get_discussions_by_feed
       get_discussions_by_hot get_discussions_by_promoted
-      get_discussions_by_trending get_discussions_by_votes
+      get_discussions_by_trending
       get_follow_count get_key_references get_open_orders
       get_owner_history get_post_discussions_by_payout
       get_potential_signatures get_recovery_request get_reward_fund
-      get_savings_withdraw_from get_savings_withdraw_to get_state
-      get_tags_used_by_author get_transaction_hex
+      get_savings_withdraw_from get_savings_withdraw_to
+      get_transaction_hex
       get_witness_by_account verify_authority)
     
     METHOD_NAMES_2_ARGS = %i(get_account_reputations
@@ -43,7 +43,10 @@ module Steem
       get_recent_trades get_ticker get_trade_history)
     
     # Plugins not enabled, or similar.
-    SKIP_METHOD_NAMES = %i(get_transaction)
+    SKIP_METHOD_NAMES = %i(get_account_votes get_blog_authors get_transaction
+      get_discussions_by_active get_discussions_by_cashout
+      get_discussions_by_children get_discussions_by_votes get_state
+      get_tags_used_by_author)
     
     ALL_METHOD_NAMES = METHOD_NAMES_1_ARG + METHOD_NAMES_2_ARGS +
       METHOD_NAMES_3_ARGS + METHOD_NAMES_4_ARGS + METHOD_NAMES_UNIMPLEMENTED +

--- a/test/steem/follow_api_test.rb
+++ b/test/steem/follow_api_test.rb
@@ -6,7 +6,12 @@ module Steem
       @api = Steem::FollowApi.new(url: TEST_NODE)
       @jsonrpc = Jsonrpc.new(url: TEST_NODE)
       @methods = @jsonrpc.get_api_methods[@api.class.api_name]
+    rescue UnknownApiError => e
+      raise e unless TEST_NODE == 'https://api.steemit.com'
+      
+      skip e.to_s
     end
+    
     def test_api_class_name
       assert_equal 'FollowApi', Steem::FollowApi::api_class_name
     end

--- a/test/steem/jsonrpc_test.rb
+++ b/test/steem/jsonrpc_test.rb
@@ -158,18 +158,6 @@ module Steem
             "verify_authority",
             "verify_signatures"
           ],
-          follow_api: [
-            "get_account_reputations",
-            "get_blog",
-            "get_blog_authors",
-            "get_blog_entries",
-            "get_feed",
-            "get_feed_entries",
-            "get_follow_count",
-            "get_followers",
-            "get_following",
-            "get_reblogged_by"
-          ],
           jsonrpc: [
             "get_methods",
             "get_signature"
@@ -187,12 +175,31 @@ module Steem
             "broadcast_block",
             "broadcast_transaction"
           ],
+          reputation_api: [
+            "get_account_reputations"
+          ],
           rc_api: [
             "find_rc_accounts",
             "get_resource_params",
             "get_resource_pool"
-          ],
-          tags_api: [
+          ]
+        }
+
+        unless TEST_NODE == 'https://api.steemit.com'
+          expected_apis[:follow_api] = [
+            "get_account_reputations",
+            "get_blog",
+            "get_blog_authors",
+            "get_blog_entries",
+            "get_feed",
+            "get_feed_entries",
+            "get_follow_count",
+            "get_followers",
+            "get_following",
+            "get_reblogged_by"
+          ]
+          
+          expected_apis[:tags_api] = [
             "get_active_votes",
             "get_comment_discussions_by_payout",
             "get_content_replies",
@@ -214,11 +221,12 @@ module Steem
             "get_tags_used_by_author",
             "get_trending_tags"
           ]
-        }
+        end
         
         api_names = expected_apis.keys.map(&:to_s)
         unexpected_apis = (api_names + apis.keys).uniq - api_names
         missing_apis = (api_names + apis.keys).uniq - apis.keys
+        
         assert_equal [], unexpected_apis, "found unexpected apis"
         assert_equal [], missing_apis, "missing expected apis"
         

--- a/test/steem/reputation_api_test.rb
+++ b/test/steem/reputation_api_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+module Steem
+  class ReputationApiTest < Steem::Test
+    def setup
+      @api = Steem::ReputationApi.new(url: TEST_NODE)
+      @jsonrpc = Jsonrpc.new(url: TEST_NODE)
+      @methods = @jsonrpc.get_api_methods[@api.class.api_name]
+    end
+    
+    def test_api_class_name
+      assert_equal 'ReputationApi', Steem::ReputationApi::api_class_name
+    end
+    
+    def test_inspect
+      assert_equal "#<ReputationApi [@chain=steem, @methods=<1 element>]>", @api.inspect
+    end
+    
+    def test_method_missing
+      assert_raises NoMethodError do
+        @api.bogus
+      end
+    end
+    
+    def test_all_respond_to
+      @methods.each do |key|
+        assert @api.respond_to?(key), "expect rpc respond to #{key}"
+      end
+    end
+    
+    def test_get_account_reputations
+      vcr_cassette('reputation_api_get_account_reputations', record: :once) do
+        options = {
+          account_lower_bound: 'alice',
+          limit: 1
+        }
+        
+        @api.get_account_reputations(options) do |result|
+          assert_equal Hashie::Array, result.reputations.class
+          assert_equal 'alice', result.reputations.first.account
+          assert_equal 0, result.reputations.first.reputation
+        end
+      end
+    end
+  end
+end

--- a/test/steem/tags_api_test.rb
+++ b/test/steem/tags_api_test.rb
@@ -6,7 +6,12 @@ module Steem
       @api = Steem::TagsApi.new(url: TEST_NODE)
       @jsonrpc = Jsonrpc.new(url: TEST_NODE)
       @methods = @jsonrpc.get_api_methods[@api.class.api_name]
+    rescue UnknownApiError => e
+      raise e unless TEST_NODE == 'https://api.steemit.com'
+      
+      skip e.to_s
     end
+    
     def test_api_class_name
       assert_equal 'TagsApi', Steem::TagsApi::api_class_name
     end


### PR DESCRIPTION
*As a developer using steem-ruby, I would like steem-ruby to handle errors from hivemind backed nodes, so that I can debug my apps easier.*

This change does two things:

1. It updates the tests so that if a node is backed by hivemind, and thus disables `tags_api` and `follow_api`, the tests that rely on those plugins are just skipped.
2. It handles and whitelists hivemind specific errors so that these tests pass.

Before this change, but after `api.steemit.com` changed configuration to include hivemind backed methods, the previous revision would have the following errors when running the test suite (e.g., running the command `bundle exec rake test`):

```
267 runs, 1628 assertions, 2 failures, 39 errors, 18 skips
```

For these tests, after this revision, the errors all pass when using the default production node.

### Application Impact

When whitelisting errors, this just means steem-ruby will not raise `Steem::UnknownError` but will raise more meaningful errors, like `Steem::ArgumentError` or `Steem::HivemindArgumentError` (which itself descends from `Steem::ArgumentError`).

To achieve this, steem-ruby will now conditionally check the response for the `.error` key (like before) or the `.result.error` key, if the error originates from hivemind.